### PR TITLE
HX-15-Alterar-versao-do-Hexagon-para-v1.0.0

### DIFF
--- a/kern/versao.asm
+++ b/kern/versao.asm
@@ -83,13 +83,13 @@ use32
 
 Hexagon.Arquitetura.suporte = 1 ;; Arquitetura desta imagem
 
-Hexagon.Versao.definicao equ "1.5.2-beta"
+Hexagon.Versao.definicao equ "1.0.0"
 
 Hexagon.Versao:
 
 .numeroVersao     = 1 ;; Número principal de versão do Hexagon
-.numeroSubversao  = 5 ;; Número de subversão (secundária) do Hexagon
-.caractereRevisao = 2 ;; Adicionar caractere de revisão, caso necessário, entre aspas (funciona como caractere)
+.numeroSubversao  = 0 ;; Número de subversão (secundária) do Hexagon
+.caractereRevisao = 0 ;; Adicionar caractere de revisão, caso necessário, entre aspas (funciona como caractere)
 
 .nomeKernel:
 db "Hexagon", 0 ;; Nome fornecido ao espaço de usuário


### PR DESCRIPTION
Versão do Hexagon alterada para v1.0.0. Essa mudança se deve à melhorias de estabilidade e novas funções que tornam o kernel minimamente acabado e estável.