### PR TITLE
Preemptive multitasking fixes and process state work

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Hexagonix Operating System
 
 BSD 3-Clause License
 
-Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes<br>
+Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes<br>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/arch/gen/mm.asm
+++ b/arch/gen/mm.asm
@@ -278,6 +278,10 @@ Hexagon.Arch.Gen.Mm.malloc:
 
     push ecx
     push edx
+    push ebx ;; Requested size, for the accounting call at .end below. The
+             ;; body repurposes EBX as scratch/return pointer throughout, so
+             ;; the original request would otherwise be lost by the time
+             ;; execution gets there
 
     mov eax, [Hexagon.Memory.Allocator.firstFreeBlock]
 
@@ -496,6 +500,17 @@ Hexagon.Arch.Gen.Mm.malloc:
 
 .end:
 
+    pop edx ;; Requested size, saved as EBX at entry, before it's known whether this call succeeded
+
+    cmp eax, 0
+    je .noAccounting
+
+    mov eax, edx
+
+    call Hexagon.Arch.Gen.Mm.confirmMemoryUsage
+
+.noAccounting:
+
     pop edx
     pop ecx
 
@@ -523,6 +538,11 @@ Hexagon.Arch.Gen.Mm.free:
     push ebx
     push ecx
     push edx
+
+    push ecx ;; Extra copy of the freed size, for the accounting call at .end
+             ;; below. The body repurposes ECX as scratch throughout, and
+             ;; the copy pushed above is only restored to the caller there,
+             ;; not usable mid-function
 
     cmp ebx, [Hexagon.Memory.Allocator.firstFreeBlock]
     jb .newFirstFree
@@ -708,6 +728,10 @@ Hexagon.Arch.Gen.Mm.free:
 
 .end:
 
+    pop eax ;; Freed size, saved as an extra copy of ECX at entry
+
+    call Hexagon.Arch.Gen.Mm.freeMemoryUsage
+
     pop edx
     pop ecx
     pop ebx
@@ -746,5 +770,13 @@ Hexagon.Arch.Gen.Mm.dilateMemorySpace:
     pop ecx
 
     add dword[Hexagon.Memory.Allocator.processReserved], ecx
+
+;; The malloc above already added this block to Hexagon.Memory.usedMemory.
+;; It is growing the allocator's own backing pool, not memory a process is
+;; actually holding, so cancel that back out here
+
+    mov eax, ecx
+
+    call Hexagon.Arch.Gen.Mm.freeMemoryUsage
 
     ret

--- a/arch/gen/mm.asm
+++ b/arch/gen/mm.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/arch/i386/APM/apm.asm
+++ b/arch/i386/APM/apm.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/arch/i386/BIOS/BIOS.asm
+++ b/arch/i386/BIOS/BIOS.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/arch/i386/CMOS/cmos.asm
+++ b/arch/i386/CMOS/cmos.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/arch/i386/cpu/cpu.asm
+++ b/arch/i386/cpu/cpu.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/arch/i386/mm/mm.asm
+++ b/arch/i386/mm/mm.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/arch/i386/timer/timer.asm
+++ b/arch/i386/timer/timer.asm
@@ -81,6 +81,7 @@ Hexagon.Arch.i386.Timer.Timer.setupTimer:
 ;; mode 3 (square wave), binary counting
 
     mov al, 00110110b
+
     out 43h, al
 
 ;; Set timer frequency to ~100 Hz (1193182 Hz / 11932)
@@ -94,38 +95,5 @@ Hexagon.Arch.i386.Timer.Timer.setupTimer:
     out 40h, al
 
     logHexagon Hexagon.Verbose.timer, Hexagon.Dmesg.Priorities.p5
-
-    ret
-
-;;************************************************************************************
-
-;; Pauses the execution of a task for the specified time
-;;
-;; Input:
-;;
-;; ECX - Time to generate delay, in counting units
-
-Hexagon.Arch.i386.Timer.Timer.sleep:
-
-    pusha
-
-    sti ;; Enable interrupts so that the counter can be updated
-
-;; Wait for an absolute tick target rather than counting discrete counter
-;; changes one at a time. A preempted process only gets to observe the
-;; counter when the scheduler resumes it, so counting "changes" undercounts
-;; real elapsed time by however many ticks went by while it was preempted.
-;; The more other processes are READY, the worse this gets. Comparing
-;; against a fixed target is immune to however many times this process gets
-;; swapped out and back in while waiting
-
-    add ecx, dword[Hexagon.Kern.Services.timerHandler.timerCounter]
-
-.wait:
-
-    cmp dword[Hexagon.Kern.Services.timerHandler.timerCounter], ecx
-    jb .wait
-
-    popa
 
     ret

--- a/arch/i386/timer/timer.asm
+++ b/arch/i386/timer/timer.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/dev/amd64/amd64.asm
+++ b/dev/amd64/amd64.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/dev/dev.asm
+++ b/dev/dev.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/dev/gen/COM/serial.asm
+++ b/dev/gen/COM/serial.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/dev/gen/PS2/PS2.asm
+++ b/dev/gen/PS2/PS2.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/dev/gen/console/console.asm
+++ b/dev/gen/console/console.asm
@@ -136,6 +136,11 @@ Hexagon.Console.textMode:
 
 ;;************************************************************************************
 
+;; Budget reserved for the VBE control block. Not yet enforced at every read/write site
+Hexagon.Console.VBE.maxSize = 90000
+
+;;************************************************************************************
+
 ;; Defines the resolution to be used for display
 ;;
 ;; Input:

--- a/dev/gen/console/console.asm
+++ b/dev/gen/console/console.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/dev/gen/keyboard/keyboard.asm
+++ b/dev/gen/keyboard/keyboard.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/dev/gen/lpt/lpt.asm
+++ b/dev/gen/lpt/lpt.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/dev/gen/mouse/mouse.asm
+++ b/dev/gen/mouse/mouse.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/dev/gen/snd/snd.asm
+++ b/dev/gen/snd/snd.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/dev/i386/disk/disk.asm
+++ b/dev/i386/disk/disk.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/dev/i386/disk/disk.asm
+++ b/dev/i386/disk/disk.asm
@@ -199,6 +199,8 @@ Hexagon.Dev.Gen.Disk:
 
 .operationCode: db 0
 
+Hexagon.Disk.DiskCache.maxSize = 200000 ;; Budget reserved for FAT/root directory reads; not yet enforced at every read site
+
 ;;************************************************************************************
 
 align 4

--- a/dev/i386/i386.asm
+++ b/dev/i386/i386.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/fs/FAT16/fat16.asm
+++ b/fs/FAT16/fat16.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/fs/dir.asm
+++ b/fs/dir.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/fs/vfs.asm
+++ b/fs/vfs.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/kern/Hexagon.asm
+++ b/kern/Hexagon.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/kern/dmesg.asm
+++ b/kern/dmesg.asm
@@ -316,7 +316,7 @@ Hexagon.Kern.Dmesg.createMessage:
 
 ;; Hexagon.Kernel.Dev.Dev.open/write below track which device is open via
 ;; global state (Hexagon.Dev.Control.*), and Hexagon.Syscall.Control.systemCall
-;; is also read here - none of that is safe to interleave between two
+;; is also read here. None of that is safe to interleave between two
 ;; processes, so this whole function runs with interrupts disabled
 
     pushfd

--- a/kern/dmesg.asm
+++ b/kern/dmesg.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/kern/init.asm
+++ b/kern/init.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/kern/kern.asm
+++ b/kern/kern.asm
@@ -132,6 +132,7 @@ include "dev/dev.asm"                   ;; Hardware management and abstraction f
 ;; Processes, process model and executable images
 
 include "kern/proc.asm"                 ;; Functions for handling processes
+include "kern/sched.asm"                ;; Round robin scheduler and context switch
 include "libkern/HAPP.asm"              ;; Functions for HAPP image processing
 include "kern/init.asm"                 ;; Functions to start user mode and first process
 
@@ -253,7 +254,7 @@ Hexagon.Autoconfig:
 
     call Hexagon.Arch.i386.Timer.Timer.setupTimer ;; Initializes the Hexagon timer service
 
-    call Hexagon.Kern.Proc.setupScheduler ;; Starts the Hexagon process scheduler
+    call Hexagon.Kern.Sched.setupScheduler ;; Starts the Hexagon process scheduler
 
     call Hexagon.Kernel.Dev.Gen.COM.Serial.setupCOM1 ;; Start first serial port for debugging
 
@@ -348,10 +349,10 @@ Hexagon.userMode:
 
 Hexagon.Heap: ;; Kernel heap
 
-Hexagon.Heap.DiskGeometry  = Hexagon.Heap               + 0           ;; Disk geometry
-Hexagon.Heap.VBE           = Hexagon.Heap.DiskGeometry  + 512         ;; Video control block
-Hexagon.Heap.DiskCache     = Hexagon.Heap.VBE           + 90000       ;; Disk cache
-Hexagon.Heap.ProcessTable  = Hexagon.Heap.DiskCache     + 200000      ;; Hexagon.Processes.Table
-Hexagon.Heap.ArgProc       = Hexagon.Heap.ProcessTable  + 5000        ;; Arguments to process
-Hexagon.Heap.Temp          = Hexagon.Heap.ArgProc       + 2000        ;; Temporary kernel data
+Hexagon.Heap.DiskGeometry  = Hexagon.Heap               + 0      ;; Disk geometry
+Hexagon.Heap.VBE           = Hexagon.Heap.DiskGeometry  + 512    ;; Video control block
+Hexagon.Heap.DiskCache     = Hexagon.Heap.VBE           + 90000  ;; Disk cache
+Hexagon.Heap.ProcessTable  = Hexagon.Heap.DiskCache     + 200000 ;; Hexagon.Processes.Table
+Hexagon.Heap.ArgProc       = Hexagon.Heap.ProcessTable  + 5000   ;; Arguments to process
+Hexagon.Heap.Temp          = Hexagon.Heap.ArgProc       + 2000   ;; Temporary kernel data
 

--- a/kern/kern.asm
+++ b/kern/kern.asm
@@ -353,6 +353,5 @@ Hexagon.Heap.DiskGeometry  = Hexagon.Heap               + 0      ;; Disk geometr
 Hexagon.Heap.VBE           = Hexagon.Heap.DiskGeometry  + 512    ;; Video control block
 Hexagon.Heap.DiskCache     = Hexagon.Heap.VBE           + 90000  ;; Disk cache
 Hexagon.Heap.ProcessTable  = Hexagon.Heap.DiskCache     + 200000 ;; Hexagon.Processes.Table
-Hexagon.Heap.ArgProc       = Hexagon.Heap.ProcessTable  + 5000   ;; Arguments to process
-Hexagon.Heap.Temp          = Hexagon.Heap.ArgProc       + 2000   ;; Temporary kernel data
+Hexagon.Heap.Temp          = Hexagon.Heap.ProcessTable  + 5000   ;; Temporary kernel data
 

--- a/kern/kern.asm
+++ b/kern/kern.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/kern/kern.asm
+++ b/kern/kern.asm
@@ -349,9 +349,9 @@ Hexagon.userMode:
 
 Hexagon.Heap: ;; Kernel heap
 
-Hexagon.Heap.DiskGeometry  = Hexagon.Heap               + 0      ;; Disk geometry
-Hexagon.Heap.VBE           = Hexagon.Heap.DiskGeometry  + 512    ;; Video control block
-Hexagon.Heap.DiskCache     = Hexagon.Heap.VBE           + 90000  ;; Disk cache
-Hexagon.Heap.ProcessTable  = Hexagon.Heap.DiskCache     + 200000 ;; Hexagon.Processes.Table
-Hexagon.Heap.Temp          = Hexagon.Heap.ProcessTable  + 5000   ;; Temporary kernel data
+Hexagon.Heap.DiskGeometry  = Hexagon.Heap+ 0      ;; Disk geometry
+Hexagon.Heap.VBE           = Hexagon.Heap.DiskGeometry + 512 ;; Video control block
+Hexagon.Heap.DiskCache     = Hexagon.Heap.VBE+ Hexagon.Console.VBE.maxSize ;; Disk cache
+Hexagon.Heap.ProcessTable  = Hexagon.Heap.DiskCache + Hexagon.Disk.DiskCache.maxSize
+Hexagon.Heap.Temp          = Hexagon.Heap.ProcessTable + Hexagon.Processes.Table.byteSize ;; Temporary kernel data
 

--- a/kern/panic.asm
+++ b/kern/panic.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/kern/parameters.asm
+++ b/kern/parameters.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/kern/proc.asm
+++ b/kern/proc.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/kern/proc.asm
+++ b/kern/proc.asm
@@ -115,7 +115,7 @@ use32
 
 ;;************************************************************************************
 ;;
-;;                    Hexagon.Processes.Table - unified process table
+;;                         Hexagon unified process table
 ;;
 ;; Every process the kernel knows about gets one slot here, whether started by
 ;; the blocking hx.exec or the non-blocking hx.spawn. hx.exec still blocks its
@@ -129,7 +129,7 @@ use32
 virtual at Hexagon.Heap.ProcessTable
 
 Hexagon.Processes.Table.state:
-times Hexagon.Processes.Table.limit db 0 ;; Hexagon.Processes.Table.States.*
+times Hexagon.Processes.Table.limit db 0
 
 Hexagon.Processes.Table.pid:
 times Hexagon.Processes.Table.limit dd 0 ;; Persistent PID, never reused while the slot is in use
@@ -154,6 +154,12 @@ times Hexagon.Processes.Table.limit dd 0 ;; Saved stack pointer while not runnin
 
 Hexagon.Processes.Table.wakeTick:
 times Hexagon.Processes.Table.limit dd 0 ;; Absolute tick target while in States.sleeping
+
+Hexagon.Processes.Table.argBase:
+times Hexagon.Processes.Table.limit dd 0 ;; Alloc process arguments buffer, own life as the process; 0 = none
+
+Hexagon.Processes.Table.tempBase:
+times Hexagon.Processes.Table.limit dd 0 ;; Alloc temp scratch buffer for process, lazily allocated on first use; 0 = none
 
 Hexagon.Processes.Table.name:
 times Hexagon.Processes.Table.limit*13 db 0 ;; Process name, space-padded, for ps/hx.getProcesses
@@ -180,6 +186,8 @@ Hexagon.Processes.Table.States.sleeping = 5
 Hexagon.Processes.Table.States.idle     = 6
 
 Hexagon.Processes.Table.stackSize = 16384 ;; Dedicated stack space carved out of each process's own block
+
+Hexagon.Kern.Proc.maxArgumentsLength = 2000 ;; Longer arguments are truncated to fit Hexagon.Processes.Table.argBase's allocation
 
 ;; Kernel's own boot-time stack, saved across the very first hx.exec (called
 ;; directly by Hexagon.Kern.Init.startUserMode, before any process exists to
@@ -337,32 +345,73 @@ Hexagon.Kern.Proc.exec:
 
     push ecx ;; Remember the new slot index across everything below
 
+    push eax ;; Remember "has arguments" (0 = no) across the allocation below
+
+;; Give this new process its own arguments buffer up front, whether or not
+;; it actually has arguments - a dedicated allocation freed at
+;; Hexagon.Kern.Proc.exit, rather than a fixed shared address any other
+;; process's own hx.exec could stomp on. Hexagon.Kern.Proc.calculateArgumentsAddress
+;; lets a process keep reading its own arguments at any later point in its
+;; life, not just once at startup, so that address has to stay this
+;; process's own for as long as it's alive
+
+    mov ebx, Hexagon.Kern.Proc.maxArgumentsLength
+
+    call Hexagon.Arch.Gen.Mm.malloc
+
+    cmp eax, 0
+    je .argAllocFailed
+
+    mov ecx, dword[esp + 4] ;; New slot index, under the flag just pushed
+
+    mov dword[Hexagon.Processes.Table.argBase + ecx * 4], ebx
+
+    mov ebx, ecx ;; Keep the slot in EBX for the rest of the argument handling below
+
+    pop eax ;; Restore "has arguments" flag
+
 ;; Check if there are arguments for the process to be loaded
 
     cmp eax, 0
     je .noArguments
 
     push esi
-    push es
 
     mov esi, edi
 
-    call Hexagon.Libkern.String.stringSize
+    call Hexagon.Libkern.String.stringSize ;; Preserves EBX, ECX, ESI, EDI, ES; EAX = length
 
     mov ecx, eax
 
     inc ecx
 
+;; Arguments longer than Hexagon.Kern.Proc.maxArgumentsLength are truncated
+;; rather than overflowing past this process's own arguments allocation,
+;; the same way Hexagon.Kern.Proc.getProcessTable caps process names to
+;; their fixed field width
+
+    cmp ecx, Hexagon.Kern.Proc.maxArgumentsLength
+    jb .argLengthOk
+
+    mov ecx, Hexagon.Kern.Proc.maxArgumentsLength - 1
+
+.argLengthOk:
+
+    push es
+
     push 18h ;; Kernel linear segment
     pop es
 
-;; Copy arguments to a known address
+;; Copy arguments into this new child's own dedicated buffer, recorded in
+;; Hexagon.Processes.Table.argBase above (EBX still holds its slot)
 
     mov esi, edi
 
-    mov edi, Hexagon.Heap.ArgProc
+    mov edi, dword[Hexagon.Processes.Table.argBase + ebx * 4]
 
     rep movsb ;; Copy (ECX) characters from ESI to EDI
+
+    mov byte[es:edi], 0 ;; Guarantee NUL-termination even when truncated above
 
     pop es
 
@@ -372,7 +421,26 @@ Hexagon.Kern.Proc.exec:
 
 .noArguments:
 
-    mov byte[gs:Hexagon.Heap.ArgProc], 0
+    mov edi, dword[Hexagon.Processes.Table.argBase + ebx * 4]
+
+    mov byte[gs:edi], 0
+
+    jmp .checkImage
+
+.argAllocFailed:
+
+    pop eax ;; Discard the "has arguments" flag pushed above
+    pop ecx ;; Discard the slot index pushed at .slotFound
+
+    popa
+
+    mov dword[Hexagon.Kern.Proc.lastErrorCode], 05h
+
+    stc
+
+    mov eax, 05h
+
+    ret
 
 .checkImage:
 
@@ -398,7 +466,7 @@ Hexagon.Kern.Proc.exec:
 
 ;; ESI = filename, EAX = size -> EBX =base, ECX =size, CF =error
 
-    call Hexagon.Kern.Proc.allocateAndLoadImage 
+    call Hexagon.Kern.Proc.allocateAndLoadImage
 
     pop edx ;; EDX = new slot index
 
@@ -406,11 +474,25 @@ Hexagon.Kern.Proc.exec:
 
 ;; EDX = slot, EBX = base, ECX = size, ESI = filename -> EAX = new pid
 
-    call Hexagon.Kern.Proc.registerSlot 
+    call Hexagon.Kern.Proc.registerSlot
 
 ;; Block whoever is calling us until this child exits. The caller is either
 ;; itself a table slot (a normal nested hx.exec) or, for the very first
 ;; hx.exec, the kernel's own boot code, which has no slot of its own
+
+;; Hexagon.Kern.Proc.registerSlot above already left EDX sitting in the
+;; table as States.ready, so a timer-driven Hexagon.Kern.Sched.maybeSchedule
+;; landing anywhere between here and Hexagon.Scheduler.current actually
+;; being moved to EDX below would find it a perfectly valid candidate,
+;; dispatch it on the spot, and in doing so overwrite the caller's own
+;; States.blocked just set below back to States.ready, the same as any
+;; ordinary preempted process. The caller would then resume, still
+;; believing itself mid-hx.exec, and re-run the rest of this function on
+;; top of whatever is by then using this slot. dispatchSlot's own "sti"
+;; closes this back out once Hexagon.Scheduler.current genuinely points at
+;; EDX
+
+    cli
 
     movzx ecx, byte[Hexagon.Scheduler.current]
 
@@ -441,7 +523,9 @@ Hexagon.Kern.Proc.exec:
 
 .missingImage:
 
-    pop ecx ;; Discard the slot index, nothing was allocated
+    pop edx ;; Slot index, pushed at .slotFound
+
+    call .freeArgBase
 
     popa
 
@@ -456,7 +540,9 @@ Hexagon.Kern.Proc.exec:
 .missingImage2:
 
     pop eax ;; Discard the saved file size
-    pop ecx ;; Discard the slot index
+    pop edx ;; Slot index, pushed at .slotFound
+
+    call .freeArgBase
 
     popa
 
@@ -471,7 +557,9 @@ Hexagon.Kern.Proc.exec:
 .incompatibleImage:
 
     pop eax ;; Discard the saved file size
-    pop ecx ;; Discard the slot index
+    pop edx ;; Slot index, pushed at .slotFound
+
+    call .freeArgBase
 
     popa
 
@@ -485,6 +573,10 @@ Hexagon.Kern.Proc.exec:
 
 .allocOrLoadFailed:
 
+;; EDX is already the slot index here, popped above at "pop edx ;; EDX = new slot index"
+
+    call .freeArgBase
+
     popa
 
     mov dword[Hexagon.Kern.Proc.lastErrorCode], 02h
@@ -492,6 +584,31 @@ Hexagon.Kern.Proc.exec:
     stc
 
     mov eax, 02h
+
+    ret
+
+;; Frees the arguments buffer Hexagon.Kern.Proc.exec allocates for this new
+;; slot up front, at .slotFound, before it's known whether the image itself
+;; can even be loaded. Every error path from here through .allocOrLoadFailed
+;; leaves the slot itself still States.free (Hexagon.Kern.Proc.registerSlot
+;; never ran), so without this the allocation would just leak: the slot
+;; stays free, a later hx.exec reusing it allocates a fresh buffer into
+;; Hexagon.Processes.Table.argBase and overwrites this pointer with no
+;; record of it left to free
+;;
+;; Input:
+;;
+;; EDX - Slot index whose argBase to free
+
+.freeArgBase:
+
+    mov ebx, dword[Hexagon.Processes.Table.argBase + edx * 4]
+
+    mov ecx, Hexagon.Kern.Proc.maxArgumentsLength
+
+    call Hexagon.Arch.Gen.Mm.free
+
+    mov dword[Hexagon.Processes.Table.argBase + edx * 4], 0
 
     ret
 
@@ -545,6 +662,50 @@ Hexagon.Kern.Proc.exit:
     call Hexagon.Arch.Gen.Mm.freeMemoryUsage
 
     pop ecx
+
+;; Free this process's own arguments buffer and hx.getProcesses scratch
+;; buffer, if it ever called hx.getProcesses - both Hexagon.Arch.Gen.Mm.malloc'd
+;; on demand and recorded per slot rather than living at a fixed address
+
+    mov ebx, dword[Hexagon.Processes.Table.argBase + edx * 4]
+
+    cmp ebx, 0
+    je .noArgBaseToFree
+
+    mov ecx, Hexagon.Kern.Proc.maxArgumentsLength
+
+    call Hexagon.Arch.Gen.Mm.free
+
+    mov dword[Hexagon.Processes.Table.argBase + edx * 4], 0
+
+.noArgBaseToFree:
+
+    mov ebx, dword[Hexagon.Processes.Table.tempBase + edx * 4]
+
+    cmp ebx, 0
+    je .noTempBaseToFree
+
+    mov ecx, Hexagon.Kern.Proc.getProcessTable.bufferSize
+
+    call Hexagon.Arch.Gen.Mm.free
+
+    mov dword[Hexagon.Processes.Table.tempBase + edx * 4], 0
+
+.noTempBaseToFree:
+
+;; Hexagon.Scheduler.current still points at edx below, and is about to
+;; keep doing so all the way through the parentSlot/bootChildSlot checks
+;; that decide who to resume. A timer-driven Hexagon.Kern.Sched.maybeSchedule
+;; landing anywhere from the States.free write below until whichever of
+;; .resumeParent/.resumeBoot/.scanNext's own cli takes over would still find
+;; Hexagon.Scheduler.current pointing at this slot, its state already
+;; States.free, and treat it as an ordinary running process to preempt,
+;; writing States.ready right back over the free slot and resurrecting it
+;; as a ghost entry with a bogus saved context, exactly the scenario the
+;; comment further below already describes for the spawned-process case,
+;; just reachable a few instructions earlier than that cli currently covers
+
+    cli
 
     mov byte[Hexagon.Processes.Table.state + edx], Hexagon.Processes.Table.States.free
 
@@ -654,6 +815,19 @@ Hexagon.Kern.Proc.exit:
 
 .resumeParent:
 
+;; Interrupts stay off until state[ecx] reaches States.running below. A
+;; timer-driven Hexagon.Kern.Sched.maybeSchedule landing anywhere in this
+;; window would find Hexagon.Scheduler.current already pointing at ecx
+;; while its state is still States.ready, and either abandon the rest of
+;; .resumeParent mid-flight via its own "ret" (leaving ecx stuck at
+;; States.ready forever, never getting setUserSegmentBase or its final
+;; States.running) or, if esp below hasn't loaded yet, save the exiting
+;; child's own esp into this slot instead of the parent's, corrupting its
+;; saved context outright. Same class of race .scanNext/.resumeNext above
+;; already closes with its own cli/sti pair
+
+    cli
+
     mov byte[Hexagon.Processes.Table.state + ecx], Hexagon.Processes.Table.States.ready
 
     mov byte[Hexagon.Scheduler.current], cl
@@ -670,6 +844,8 @@ Hexagon.Kern.Proc.exit:
 
     mov byte[Hexagon.Processes.Table.state + ecx], Hexagon.Processes.Table.States.running
 
+    sti
+
     popa
 
     xor eax, eax
@@ -683,6 +859,12 @@ Hexagon.Kern.Proc.exit:
     mov byte[Hexagon.Scheduler.current], 0xFF
 
     mov esp, dword[Hexagon.Kern.Proc.bootCallerESP]
+
+;; Re-enable interrupts now that Hexagon.Scheduler.current is 0xFF (raw
+;; kernel-boot context) rather than this now-free slot; see the cli before
+;; the States.free write above
+
+    sti
 
     popa
 
@@ -770,7 +952,9 @@ Hexagon.Kern.Proc.calculateArgumentsAddress:
 
     call Hexagon.Kern.Sched.getCurrentProcessBase
 
-    mov edi, Hexagon.Heap.ArgProc ;; Offset, inside the kernel
+    movzx edi, byte[Hexagon.Scheduler.current]
+
+    mov edi, dword[Hexagon.Processes.Table.argBase + edi * 4] ;; This process's own allocated arguments buffer
 
     sub edi, eax ;; Get effective address (offset)
 
@@ -780,9 +964,10 @@ Hexagon.Kern.Proc.calculateArgumentsAddress:
 
 ;;************************************************************************************
 
-;; Hexagon.Kern.Proc.getProcessTable emits into Hexagon.Heap.Temp a 4-byte
-;; record size, followed by one record per Hexagon.Processes.Table slot that
-;; isn't FREE, in slot order, each shaped like this:
+;; Hexagon.Kern.Proc.getProcessTable emits into this caller's own
+;; Hexagon.Processes.Table.tempBase buffer a 4-byte record size, followed by
+;; one record per Hexagon.Processes.Table slot that isn't FREE, in slot
+;; order, each shaped like this:
 ;;
 ;; +0  dd PID
 ;; +4  dd Parent PID (0 = launched directly by the kernel, no parent process)
@@ -795,17 +980,52 @@ Hexagon.Kern.Proc.calculateArgumentsAddress:
 
 Hexagon.Kern.Proc.getProcessTable.recordSize = 22
 
+;; Hexagon.Processes.Table.tempBase is this large, lazily
+;; Hexagon.Arch.Gen.Mm.malloc'd on this caller's first hx.getProcesses call
+;; and kept for the rest of its life (freed at Hexagon.Kern.Proc.exit)
+;; rather than a single shared buffer. ps/top keep reading their result
+;; across many further syscalls while printing each row, and a single
+;; shared buffer would let any other process's own concurrent
+;; hx.getProcesses call - init's own child monitoring loop calls this
+;; constantly - overwrite it out from under a slower reader mid-print
+
+Hexagon.Kern.Proc.getProcessTable.bufferSize = 4 + (Hexagon.Processes.Table.limit * Hexagon.Kern.Proc.getProcessTable.recordSize)
+
 ;; Output:
 ;;
-;; EAX - Number of records
-;; ESI - Hexagon.Heap.Temp: a dd record size, followed by that many records
+;; EAX - Number of records, or 0 if this caller's own scratch buffer
+;;       couldn't be allocated (out of memory)
+;; ESI - This caller's own Hexagon.Processes.Table.tempBase buffer: a dd
+;;       record size, followed by that many records
 
 Hexagon.Kern.Proc.getProcessTable:
 
     push ds ;; Kernel data segment
     pop es
 
-    mov edi, Hexagon.Heap.Temp
+    movzx edx, byte[Hexagon.Scheduler.current]
+
+    mov edi, dword[Hexagon.Processes.Table.tempBase + edx * 4]
+
+    cmp edi, 0
+    jne .bufferReady
+
+    push ebx
+
+    mov ebx, Hexagon.Kern.Proc.getProcessTable.bufferSize
+
+    call Hexagon.Arch.Gen.Mm.malloc
+
+    cmp eax, 0
+    je .allocFailed
+
+    mov edi, ebx
+
+    pop ebx
+
+    mov dword[Hexagon.Processes.Table.tempBase + edx * 4], edi
+
+.bufferReady:
 
     mov dword[edi], Hexagon.Kern.Proc.getProcessTable.recordSize
 
@@ -886,7 +1106,17 @@ Hexagon.Kern.Proc.getProcessTable:
 
     mov eax, edx
 
-    mov esi, Hexagon.Heap.Temp
+    movzx esi, byte[Hexagon.Scheduler.current]
+    mov esi, dword[Hexagon.Processes.Table.tempBase + esi * 4]
+
+    ret
+
+.allocFailed:
+
+    pop ebx
+
+    xor eax, eax
+    xor esi, esi
 
     ret
 
@@ -1051,6 +1281,35 @@ Hexagon.Kern.Proc.registerSlot:
 
     pop ecx
     pop ebx
+
+;; Hexagon.Kern.Proc.spawn doesn't support arguments and never fills in
+;; Hexagon.Processes.Table.argBase, so give this slot an empty one here if
+;; Hexagon.Kern.Proc.exec hasn't already allocated and filled one in above.
+;; Hexagon.Kern.Proc.calculateArgumentsAddress always computes an address
+;; from this field regardless of how the process was created, so it must
+;; never be left at 0
+
+    cmp dword[Hexagon.Processes.Table.argBase + edx * 4], 0
+    jne .argBaseReady
+
+    push ebx
+
+    mov ebx, Hexagon.Kern.Proc.maxArgumentsLength
+
+    call Hexagon.Arch.Gen.Mm.malloc
+
+    cmp eax, 0
+    je .argBaseSkip ;; Best effort; leave it 0 on out-of-memory rather than failing an already-loaded process
+
+    mov dword[Hexagon.Processes.Table.argBase + edx * 4], ebx
+
+    mov byte[gs:ebx], 0 ;; Empty arguments string
+
+.argBaseSkip:
+
+    pop ebx
+
+.argBaseReady:
 
     inc dword[Hexagon.Processes.Table.nextPID]
 

--- a/kern/proc.asm
+++ b/kern/proc.asm
@@ -166,7 +166,9 @@ times Hexagon.Processes.Table.limit*13 db 0 ;; Process name, space-padded, for p
 
 Hexagon.Processes.Table.nextPID: dd 0 ;; Monotonic counter, next PID to hand out
 
-Hexagon.Processes.Table.limit = 16
+Hexagon.Processes.Table.byteSize = $ - Hexagon.Heap.ProcessTable ;; Real size, so Hexagon.Heap.Temp never has to guess a gap
+
+Hexagon.Processes.Table.limit = 40
 
 end virtual
 
@@ -650,18 +652,10 @@ Hexagon.Kern.Proc.exit:
     push ebx
     push ecx
 
-    call Hexagon.Arch.Gen.Mm.free
+    call Hexagon.Arch.Gen.Mm.free ;; Now accounts for Hexagon.Memory.usedMemory itself
 
     pop ecx
     pop ebx
-
-    push ecx
-
-    mov eax, ecx
-
-    call Hexagon.Arch.Gen.Mm.freeMemoryUsage
-
-    pop ecx
 
 ;; Free this process's own arguments buffer and hx.getProcesses scratch
 ;; buffer, if it ever called hx.getProcesses - both Hexagon.Arch.Gen.Mm.malloc'd
@@ -1272,16 +1266,6 @@ Hexagon.Kern.Proc.registerSlot:
 
     mov dword[Hexagon.Processes.Table.esp + edx * 4], 0 ;; Never dispatched yet
 
-    push ebx
-    push ecx
-
-    mov eax, ecx
-
-    call Hexagon.Arch.Gen.Mm.confirmMemoryUsage ;; Accounting
-
-    pop ecx
-    pop ebx
-
 ;; Hexagon.Kern.Proc.spawn doesn't support arguments and never fills in
 ;; Hexagon.Processes.Table.argBase, so give this slot an empty one here if
 ;; Hexagon.Kern.Proc.exec hasn't already allocated and filled one in above.
@@ -1538,6 +1522,13 @@ Hexagon.Kern.Proc.kill:
 
 .slotFound:
 
+;; Slot 0 is the permanent idle process, never allocated like a real process.
+;; Tearing it down here would free a bogus base/size and erase the scheduler's
+;; last-resort fallback, so refuse exactly like an unknown PID instead
+
+    cmp ecx, Hexagon.Kern.Sched.idleSlot
+    je .notFound
+
     movzx edx, byte[Hexagon.Scheduler.current]
 
     cmp ecx, edx
@@ -1559,18 +1550,10 @@ Hexagon.Kern.Proc.kill:
     push ebx
     push ecx
 
-    call Hexagon.Arch.Gen.Mm.free
+    call Hexagon.Arch.Gen.Mm.free ;; Now accounts for Hexagon.Memory.usedMemory itself
 
     pop ecx
     pop ebx
-
-    push ecx
-
-    mov eax, ecx
-
-    call Hexagon.Arch.Gen.Mm.freeMemoryUsage
-
-    pop ecx
 
     mov byte[Hexagon.Processes.Table.state + edx], Hexagon.Processes.Table.States.free
 

--- a/kern/proc.asm
+++ b/kern/proc.asm
@@ -121,7 +121,7 @@ use32
 ;; the blocking hx.exec or the non-blocking hx.spawn. hx.exec still blocks its
 ;; caller exactly as before: the caller's own slot just sits in the BLOCKED
 ;; state until its child exits, instead of the child being a nested call on
-;; the raw CPU stack, so Hexagon.Kern.Proc.maybeSchedule can round-robin
+;; the raw CPU stack, so Hexagon.Kern.Sched.maybeSchedule can round-robin
 ;; between an exec chain and independently spawned processes uniformly
 ;;
 ;;************************************************************************************
@@ -152,6 +152,9 @@ times Hexagon.Processes.Table.limit dd 0 ;; HAPP entry point; only meaningful be
 Hexagon.Processes.Table.esp:
 times Hexagon.Processes.Table.limit dd 0 ;; Saved stack pointer while not running; 0 = never dispatched
 
+Hexagon.Processes.Table.wakeTick:
+times Hexagon.Processes.Table.limit dd 0 ;; Absolute tick target while in States.sleeping
+
 Hexagon.Processes.Table.name:
 times Hexagon.Processes.Table.limit*13 db 0 ;; Process name, space-padded, for ps/hx.getProcesses
 
@@ -161,11 +164,12 @@ Hexagon.Processes.Table.limit = 16
 
 end virtual
 
-Hexagon.Processes.Table.States.free    = 0
-Hexagon.Processes.Table.States.ready   = 1
-Hexagon.Processes.Table.States.running = 2
-Hexagon.Processes.Table.States.blocked = 3
-Hexagon.Processes.Table.States.zombie  = 4
+Hexagon.Processes.Table.States.free     = 0
+Hexagon.Processes.Table.States.ready    = 1
+Hexagon.Processes.Table.States.running  = 2
+Hexagon.Processes.Table.States.blocked  = 3
+Hexagon.Processes.Table.States.zombie   = 4
+Hexagon.Processes.Table.States.sleeping = 5
 
 Hexagon.Processes.Table.stackSize = 16384 ;; Dedicated stack space carved out of each process's own block
 
@@ -215,33 +219,10 @@ Hexagon.Kern.Proc.lock:
 
 ;;************************************************************************************
 
-Hexagon.Kern.Proc.setupScheduler:
-
-    logHexagon Hexagon.Verbose.heapKernel, Hexagon.Dmesg.Priorities.p5
-
-    push ds
-    pop es
-
-    mov edi, Hexagon.Processes.Table.state
-    mov ecx, Hexagon.Processes.Table.limit
-    mov al, Hexagon.Processes.Table.States.free
-
-    rep stosb
-
-    mov dword[Hexagon.Processes.Table.nextPID], 0
-
-    mov byte[Hexagon.Scheduler.current], 0xFF
-
-    logHexagon Hexagon.Verbose.scheduler, Hexagon.Dmesg.Priorities.p5
-
-    ret
-
-;;************************************************************************************
-
 ;; Allows you to terminate a process currently running by the system, if such
 ;; termination is possible
 
-Hexagon.Kern.Proc.kill:
+Hexagon.Kern.Proc.killForegroundProcess:
 
 ;; End current running process
 
@@ -448,7 +429,7 @@ Hexagon.Kern.Proc.exec:
 
     mov ebx, edx
 
-    jmp Hexagon.Kern.Proc.dispatchSlot ;; Builds the child's iret frame and never returns here
+    jmp Hexagon.Kern.Sched.dispatchSlot ;; Builds the child's iret frame and never returns here
 
 .missingImage:
 
@@ -561,8 +542,8 @@ Hexagon.Kern.Proc.exit:
 
 ;; Resume whoever is blocked waiting for this process, if anyone, either the
 ;; parent slot that called hx.exec, or the kernel's own boot code for the
-;; very first process - using the exact same esp-restore mechanism
-;; Hexagon.Kern.Proc.maybeSchedule already uses to resume any other process
+;; very first process, using the exact same esp-restore mechanism
+;; Hexagon.Kern.Sched.maybeSchedule already uses to resume any other process
 
     mov ecx, dword[Hexagon.Processes.Table.parentSlot + edx * 4]
 
@@ -609,13 +590,13 @@ Hexagon.Kern.Proc.exit:
     cmp dword[Hexagon.Processes.Table.esp + ebx * 4], 0
     jne .resumeNext
 
-    jmp Hexagon.Kern.Proc.dispatchSlot ;; First ever dispatch of this slot
+    jmp Hexagon.Kern.Sched.dispatchSlot ;; First ever dispatch of this slot
 
 .resumeNext:
 
     mov eax, dword[Hexagon.Processes.Table.base + ebx * 4]
 
-    call Hexagon.Kern.Proc.setUserSegmentBase
+    call Hexagon.Kern.Sched.setUserSegmentBase
 
     mov esp, dword[Hexagon.Processes.Table.esp + ebx * 4]
 
@@ -641,7 +622,7 @@ Hexagon.Kern.Proc.exit:
 
     push ecx
 
-    call Hexagon.Kern.Proc.setUserSegmentBase
+    call Hexagon.Kern.Sched.setUserSegmentBase
 
     pop ecx
 
@@ -745,7 +726,7 @@ Hexagon.Kern.Proc.calculateArgumentsAddress:
 
     push eax
 
-    call Hexagon.Kern.Proc.getCurrentProcessBase
+    call Hexagon.Kern.Sched.getCurrentProcessBase
 
     mov edi, Hexagon.Heap.ArgProc ;; Offset, inside the kernel
 
@@ -1101,7 +1082,7 @@ Hexagon.Kern.Proc.registerSlot:
 
 ;; Creates a new process without blocking the caller. Fully validated,
 ;; allocated and loaded, then left READY in the process table for
-;; Hexagon.Kern.Proc.maybeSchedule to dispatch on its own schedule. Does not
+;; Hexagon.Kern.Sched.maybeSchedule to dispatch on its own schedule. Does not
 ;; support arguments yet, unlike hx.exec
 ;;
 ;; Input:
@@ -1219,9 +1200,10 @@ Hexagon.Kern.Proc.spawn:
 ;;************************************************************************************
 
 ;; Terminates an arbitrary process by PID, requested through hx.kill. Unlike
-;; Hexagon.Kern.Proc.kill (the F1 hotkey handler, which always targets whichever
-;; process is currently in the foreground), this looks the target up in
-;; Hexagon.Processes.Table and can be called from any process against any other
+;; Hexagon.Kern.Proc.killForegroundProcess (the F1 hotkey handler, which
+;; always targets whichever process is currently in the foreground), this
+;; looks the target up in Hexagon.Processes.Table and can be called from any
+;; process against any other
 ;;
 ;; Input:
 ;;
@@ -1232,7 +1214,7 @@ Hexagon.Kern.Proc.spawn:
 ;; CF - Set on error (no process with this PID); EAX = 05h
 ;;      Cleared on success
 
-Hexagon.Kern.Proc.killPID:
+Hexagon.Kern.Proc.kill:
 
     xor ecx, ecx
 
@@ -1291,8 +1273,37 @@ Hexagon.Kern.Proc.killPID:
 
     mov byte[Hexagon.Processes.Table.state + edx], Hexagon.Processes.Table.States.free
 
+;; If the process being killed had itself exec'd a child that hasn't
+;; finished yet (sh running the "kill" command that then targets sh's
+;; own PID), that child's parentSlot still points at this slot. Left alone,
+;; the child's own eventual hx.exit would resume this slot through the
+;; base/esp it still remembers, even though the memory backing it was just
+;; freed above and may belong to someone else by then. Sever the link so
+;; exit treats it as an orphan instead, the same path already used for
+;; hx.spawn'd processes with no blocking caller
+
+    xor ebx, ebx
+
+.severChildren:
+
+    cmp ebx, Hexagon.Processes.Table.limit
+    jae .wakeParent
+
+    cmp dword[Hexagon.Processes.Table.parentSlot + ebx * 4], edx
+    jne .nextChild
+
+    mov dword[Hexagon.Processes.Table.parentSlot + ebx * 4], 0xFFFFFFFF
+
+.nextChild:
+
+    inc ebx
+
+    jmp .severChildren
+
+.wakeParent:
+
 ;; If another process's hx.exec is BLOCKED waiting on this one, wake it by
-;; marking it READY. Hexagon.Kern.Proc.maybeSchedule will resume it through
+;; marking it READY. Hexagon.Kern.Sched.maybeSchedule will resume it through
 ;; the normal round-robin path on its own next turn. This does not reproduce
 ;; Hexagon.Kern.Proc.exit's own resume trick (swapping ESP to jump straight
 ;; into the parent), which would hijack the caller's own stack here instead
@@ -1317,204 +1328,5 @@ Hexagon.Kern.Proc.killPID:
     stc
 
     mov eax, 05h
-
-    ret
-
-;;************************************************************************************
-;;
-;;                     Round-robin scheduler over Hexagon.Processes.Table
-;;
-;;************************************************************************************
-
-Hexagon.Scheduler.current: db 0xFF ;; 0xFF = kernel boot context, else a Hexagon.Processes.Table index
-Hexagon.Scheduler.ticks: dd 0
-Hexagon.Scheduler.sliceLength = 5 ;; Timer ticks per time-slice
-
-;;************************************************************************************
-
-;; Reprograms the user code/data segment base in the GDT
-;;
-;; Input:
-;;
-;; EAX - New base address (preserved across the call)
-
-Hexagon.Kern.Proc.setUserSegmentBase:
-
-    push eax
-    push edx
-
-    mov edx, eax
-    and eax, 0xFFFF
-
-    mov word[GDT.userCode + 2], ax
-    mov word[GDT.userData + 2], ax
-
-    mov eax, edx
-    shr eax, 16
-    and eax, 0xFF
-
-    mov byte[GDT.userCode + 4], al
-    mov byte[GDT.userData + 4], al
-
-    mov eax, edx
-    shr eax, 24
-    and eax, 0xFF
-
-    mov byte[GDT.userCode + 7], al
-    mov byte[GDT.userData + 7], al
-
-    lgdt[GDTReg]
-
-    pop edx
-    pop eax
-
-    ret
-
-;;************************************************************************************
-
-;; Builds a fresh iret frame for a slot's very first dispatch and jumps into
-;; it. Shared by Hexagon.Kern.Proc.exec (launching a fresh child) and
-;; Hexagon.Kern.Proc.maybeSchedule (first dispatch of a spawned process).
-;; Never returns to its caller. Reached with a plain "jmp", not "call"
-;;
-;; Input:
-;;
-;; EBX - Slot index to dispatch
-
-Hexagon.Kern.Proc.dispatchSlot:
-
-    mov eax, dword[Hexagon.Processes.Table.base + ebx * 4]
-
-    call Hexagon.Kern.Proc.setUserSegmentBase
-
-    mov ecx, dword[Hexagon.Processes.Table.size + ebx * 4]
-
-    add eax, ecx
-    sub eax, 4 ;; Small headroom from the very top of the block
-
-    mov esp, eax ;; Top of this process's own allocated block
-
-    call Hexagon.Kern.Proc.calculateArgumentsAddress ;; EDI = arguments address for the new process
-
-    sti ;; Make sure interrupts are available
-
-    pushfd   ;; Flags
-    push 30h ;; User environment code segment (process)
-    push dword[Hexagon.Processes.Table.entry + ebx * 4] ;; Image entry point
-
-    mov ax, 38h ;; User environment data segment (process)
-    mov ds, ax
-
-    iret
-
-;;************************************************************************************
-
-;; Called from Hexagon.Kern.Services.timerHandler, via "call", once per
-;; time-slice. At that point EAX and DS are already saved on the current
-;; stack and ds already points at the kernel data segment. Looks for the next
-;; READY process in round-robin order. Ends with a plain "ret" either way:
-;; with nothing else ready, that returns to the caller normally; when
-;; switching, it returns into whatever context is being resumed, at the same
-;; point in its own earlier call to this function, using the stack-swap
-;; itself to carry the CPU state across
-
-Hexagon.Kern.Proc.maybeSchedule:
-
-    pusha
-
-    movzx edx, byte[Hexagon.Scheduler.current] ;; EDX = who is running now
-
-    cmp edx, 0xFF
-    je .noSwitch ;; Still in raw kernel-boot context, nothing to preempt yet
-
-    mov ebx, edx ;; EBX = scan cursor
-
-.scan:
-
-    inc ebx
-
-    cmp ebx, Hexagon.Processes.Table.limit
-    jb .checkCandidate
-
-    xor ebx, ebx
-
-.checkCandidate:
-
-;; Scanned all the way back to whoever is already running. Nobody else is
-;; ready, stay put
-
-    cmp ebx, edx
-    je .noSwitch
-
-    cmp byte[Hexagon.Processes.Table.state + ebx], Hexagon.Processes.Table.States.ready
-    je .candidateValid
-
-    jmp .scan
-
-.candidateValid:
-
-;; EBX = target slot to switch to, EDX = who is running now
-
-    mov dword[Hexagon.Processes.Table.esp + edx * 4], esp
-
-    mov byte[Hexagon.Processes.Table.state + edx], Hexagon.Processes.Table.States.ready
-    mov byte[Hexagon.Processes.Table.state + ebx], Hexagon.Processes.Table.States.running
-
-    mov byte[Hexagon.Scheduler.current], bl
-
-    cmp dword[Hexagon.Processes.Table.esp + ebx * 4], 0
-    jne .resumeSlot
-
-    jmp Hexagon.Kern.Proc.dispatchSlot ;; First ever dispatch of this slot
-
-.resumeSlot:
-
-    mov eax, dword[Hexagon.Processes.Table.base+ebx*4]
-
-    call Hexagon.Kern.Proc.setUserSegmentBase
-
-    mov esp, dword[Hexagon.Processes.Table.esp+ebx*4]
-
-    popa
-
-    ret
-
-.noSwitch:
-
-    popa
-
-    ret
-
-;;************************************************************************************
-
-;; Returns the physical base address of whichever process is actually
-;; running right now. Hexagon.Kern.Syscall.hexagonHandler uses this to
-;; translate ESI/EDI, and Hexagon.Libkern.Graphics.drawBlockSyscall uses it
-;; the same way for graphics coordinates
-;;
-;; Output:
-;;
-;; EAX - Base address, or 0 if no process is running
-
-Hexagon.Kern.Proc.getCurrentProcessBase:
-
-    push ebx
-
-    movzx ebx, byte[Hexagon.Scheduler.current]
-
-    cmp ebx, 0xFF
-    je .none
-
-    mov eax, dword[Hexagon.Processes.Table.base + ebx * 4]
-
-    jmp .end
-
-.none:
-
-    xor eax, eax
-
-.end:
-
-    pop ebx
 
     ret

--- a/kern/proc.asm
+++ b/kern/proc.asm
@@ -171,6 +171,14 @@ Hexagon.Processes.Table.States.blocked  = 3
 Hexagon.Processes.Table.States.zombie   = 4
 Hexagon.Processes.Table.States.sleeping = 5
 
+;; Permanently owned by Hexagon.Kern.Sched.idleSlot, never anyone else's.
+;; Deliberately distinct from States.ready so the ordinary round robin scans
+;; in Hexagon.Kern.Sched.maybeSchedule/Hexagon.Kern.Sched.sleep skip straight
+;; over it instead of giving it a turn on equal footing with real work; only
+;; Hexagon.Kern.Proc.exit's own "nothing else is READY" fallback looks for it
+
+Hexagon.Processes.Table.States.idle     = 6
+
 Hexagon.Processes.Table.stackSize = 16384 ;; Dedicated stack space carved out of each process's own block
 
 ;; Kernel's own boot-time stack, saved across the very first hx.exec (called
@@ -562,6 +570,21 @@ Hexagon.Kern.Proc.exit:
 ;; other process is READY next, exactly like a normal preemption would.
 ;; There is no specific caller context to return to here
 
+;; Hexagon.Scheduler.current still points at this slot, which the state=free
+;; write above already turned into stale garbage. A concurrent, timer-driven
+;; Hexagon.Kern.Sched.maybeSchedule reading Hexagon.Scheduler.current before
+;; the scan below settles on someone real would treat this freed slot as an
+;; ordinary running process to preempt, saving its own ESP there and marking
+;; it READY again, resurrecting it as a ghost entry with a bogus saved
+;; context. Interrupts stay off until .scheduleNext/.resumeNext (or
+;; dispatchSlot's own "sti") has moved Hexagon.Scheduler.current somewhere
+;; real, closing the window entirely rather than just narrowing it: the wait
+;; for someone to become READY can now take up to roughly a second (parked
+;; in Hexagon.Kern.Sched.idleSlot), not just the few instructions this scan
+;; used to take
+
+    cli
+
     mov ebx, edx
 
 .scanNext:
@@ -576,12 +599,24 @@ Hexagon.Kern.Proc.exit:
 .checkNext:
 
     cmp ebx, edx
-    je .resumeBoot ;; Nothing else is READY either, fall back to the boot context
+    je .useIdleSlot ;; Nothing else is READY either. Everyone still around
+                    ;; (init, typically) is presumably just asleep in
+                    ;; Hexagon.Kern.Sched.sleep, not gone, so this is not the
+                    ;; boot child exiting
 
     cmp byte[Hexagon.Processes.Table.state + ebx], Hexagon.Processes.Table.States.ready
     je .scheduleNext
 
     jmp .scanNext
+
+.useIdleSlot:
+
+;; Dispatch Hexagon.Kern.Sched.idleSlot exactly like any other READY
+;; candidate below. It is never itself in States.ready (see the comment by
+;; States.idle), which is what keeps it out of everyone else's round robin,
+;; but it is always available as this last resort
+
+    mov ebx, Hexagon.Kern.Sched.idleSlot
 
 .scheduleNext:
 
@@ -601,6 +636,13 @@ Hexagon.Kern.Proc.exit:
     mov esp, dword[Hexagon.Processes.Table.esp + ebx * 4]
 
     mov byte[Hexagon.Processes.Table.state + ebx], Hexagon.Processes.Table.States.running
+
+;; Re-enable interrupts now that Hexagon.Scheduler.current (set above, in
+;; .scheduleNext) points at ebx instead of the freed slot this fallback
+;; started from; see the "cli" before .scanNext. dispatchSlot, the other
+;; place .scheduleNext can lead to, already has its own "sti"
+
+    sti
 
     popa
 

--- a/kern/sched.asm
+++ b/kern/sched.asm
@@ -108,6 +108,8 @@ Hexagon.Kern.Sched.setupScheduler:
 
     mov byte[Hexagon.Scheduler.current], 0xFF
 
+    call Hexagon.Kern.Sched.installIdle
+
     logHexagon Hexagon.Verbose.scheduler, Hexagon.Dmesg.Priorities.p5
 
     ret
@@ -120,7 +122,7 @@ Hexagon.Kern.Sched.setupScheduler:
 
 Hexagon.Scheduler.current: db 0xFF ;; 0xFF = kernel boot context, else a Hexagon.Processes.Table index
 Hexagon.Scheduler.ticks:   dd 0
-Hexagon.Scheduler.sliceLength = 5  ;; Timer ticks per time-slice
+Hexagon.Scheduler.sliceLength = 1  ;; Timer ticks per time-slice
 
 ;;************************************************************************************
 
@@ -334,6 +336,128 @@ Hexagon.Kern.Sched.maybeSchedule:
 .noSwitch:
 
     popa
+
+    ret
+
+;;************************************************************************************
+
+;; Slot 0 is permanently reserved for the idle loop below, installed once at
+;; boot by Hexagon.Kern.Sched.installIdle, before init (PID 1) ever runs.
+;; Unlike every other slot, it is never hx.spawn/hx.exec'd from a HAPP file
+;; on disk and never exits; it is simply always there, in
+;; Hexagon.Processes.Table.States.idle, as the last-resort candidate
+;; Hexagon.Kern.Proc.exit's own "nothing else is READY" fallback dispatches
+
+Hexagon.Kern.Sched.idleSlot = 0
+
+Hexagon.Kern.Sched.idleName:
+db "idle", 0
+
+;; The idle loop itself. Note this is never reached through
+;; Hexagon.Kern.Sched.dispatchSlot/iret like a normal HAPP image's first
+;; dispatch: dispatchSlot treats Hexagon.Processes.Table.entry as an offset
+;; relative to Table.base, since a real process is relocated to start at its
+;; own allocated block, and patches the 30h/38h GDT descriptors' base to
+;; match. idleLoop is not a relocatable image, it is this fixed address in
+;; the kernel's own code, so Hexagon.Kern.Sched.installIdle instead seeds a
+;; synthetic frame below for Hexagon.Kern.Proc.exit's ordinary ".resumeNext"
+;; path to "return" into directly, the same plain "ret" (no segment change)
+;; it already uses to resume any other process's own saved context. Once
+;; running, it needs no special handling at all: the timer interrupt's own
+;; Hexagon.Kern.Sched.maybeSchedule preempts it away, and later resumes it,
+;; exactly like it already does between any two ordinary processes
+
+Hexagon.Kern.Sched.idleLoop:
+
+.spin:
+
+    sti
+
+    hlt
+
+    jmp .spin
+
+;; Dedicated stack for Hexagon.Kern.Sched.idleLoop, with a synthetic,
+;; ready-made ".resumeNext" frame pre-built at the top: 8 dummy registers in
+;; popa's own load order (EDI, ESI, EBP, a discarded saved-ESP slot, EBX,
+;; EDX, ECX, EAX), followed by idleLoop's own address in the spot where
+;; "ret" expects to find one. Hexagon.Kern.Sched.installIdle points
+;; Table.esp at Hexagon.Kern.Sched.idleFrame, so the very first time
+;; anything dispatches Hexagon.Kern.Sched.idleSlot, popa harmlessly loads
+;; zeroes and "ret" lands on idleLoop, no differently from every later
+;; resume once real register/return values have been saved there instead
+
+Hexagon.Kern.Sched.idleStack:
+times 480 db 0
+Hexagon.Kern.Sched.idleFrame:
+dd 0, 0, 0, 0, 0, 0, 0, 0
+dd Hexagon.Kern.Sched.idleLoop
+Hexagon.Kern.Sched.idleStackTop:
+
+;; Installs the idle loop into Hexagon.Kern.Sched.idleSlot. Called once from
+;; Hexagon.Kern.Sched.setupScheduler, before init is ever dispatched.
+;; Bypasses Hexagon.Kern.Proc.registerSlot, since that expects a HAPP image
+;; already loaded from disk (Hexagon.Libkern.HAPP.imageHAPPHeader,
+;; Hexagon.Processes.Table.nextPID) and idle has neither: its "image" is the
+;; loop above, hand-placed here, and it keeps PID 0 forever rather than
+;; taking the next one init would otherwise get
+
+Hexagon.Kern.Sched.installIdle:
+
+    push ds
+    pop es
+
+    mov byte[Hexagon.Processes.Table.state + Hexagon.Kern.Sched.idleSlot], Hexagon.Processes.Table.States.idle
+
+    mov dword[Hexagon.Processes.Table.pid + Hexagon.Kern.Sched.idleSlot * 4], 0
+    mov dword[Hexagon.Processes.Table.parentSlot + Hexagon.Kern.Sched.idleSlot * 4], 0xFFFFFFFF
+    mov dword[Hexagon.Processes.Table.parentPID + Hexagon.Kern.Sched.idleSlot * 4], 0
+
+;; Table.base and Table.esp end up loaded straight into ESP (here, and in
+;; every ordinary resume) and passed to setUserSegmentBase, both of which
+;; treat them as flat physical addresses, the same way SS (0018h) itself
+;; has base 0 rather than the 500h every plain "[label]" access already gets
+;; from DS/CS. A real process's Table.base comes from Mm.allocate, already
+;; physical; idleStack/idleFrame are ordinary kernel-image labels instead,
+;; so they need the same "+ 500h" correction syscall.asm/fat16.asm already
+;; apply whenever a kernel-image address crosses over to that flat side.
+;; Table.entry (unused here, .resumeNext never falls into dispatchSlot for
+;; idleSlot: Table.esp is never 0) and the frame's own saved "return
+;; address" are the other way around, read back through CS/DS, so they are
+;; left exactly as the assembler already computed them
+
+    mov dword[Hexagon.Processes.Table.base + Hexagon.Kern.Sched.idleSlot * 4], Hexagon.Kern.Sched.idleStack + 500h
+    mov dword[Hexagon.Processes.Table.size + Hexagon.Kern.Sched.idleSlot * 4], Hexagon.Kern.Sched.idleStackTop - Hexagon.Kern.Sched.idleStack
+    mov dword[Hexagon.Processes.Table.entry + Hexagon.Kern.Sched.idleSlot * 4], Hexagon.Kern.Sched.idleLoop
+    mov dword[Hexagon.Processes.Table.esp + Hexagon.Kern.Sched.idleSlot * 4], Hexagon.Kern.Sched.idleFrame + 500h
+
+    mov edi, Hexagon.Kern.Sched.idleSlot
+    imul edi, 13
+    add edi, Hexagon.Processes.Table.name
+
+    mov esi, Hexagon.Kern.Sched.idleName
+    mov ecx, 13
+
+.copyName:
+
+    lodsb
+
+    cmp al, 0
+    je .padName
+
+    stosb
+
+    loop .copyName
+
+    jmp .named
+
+.padName:
+
+    mov al, ' '
+
+    rep stosb
+
+.named:
 
     ret
 

--- a/kern/sched.asm
+++ b/kern/sched.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/kern/sched.asm
+++ b/kern/sched.asm
@@ -1,0 +1,475 @@
+;;************************************************************************************
+;;
+;; 88       88
+;; 88       88
+;; 88       88  ,adPPPba, 8b,     ,d8 ,adPPPPba,  ,adPPPb,d8  ,adPPPba,    ,dPPPba,
+;; 88PPPPPPP88 a8P     88  `P8, ,8P'  ""     `P8 a8"    `P88 a8"     "8a 88P'   `"88
+;; 88       88 8PP"""""""    )888(    ,adPPPPP88 8b       88 8b       d8 88       88
+;; 88       88 '8b,   ,aa  ,d8" "8b,  88,    ,88 "8a,   ,d88 "8a,   ,a8" 88       88
+;; 88       88  `"Pbbd8"' 8P'     `P8 `"8bbdP"P8  `"PbbdP"P8  `"PbbdP"'  88       88
+;;                                                aa,    ,88
+;;                                                 "P8bbdP"
+;;
+;;                          Kernel Hexagon - Hexagon kernel
+;;
+;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                Todos os direitos reservados - All rights reserved.
+;;
+;;************************************************************************************
+;;
+;; Português:
+;;
+;; O Hexagon, Hexagonix e seus componentes são licenciados sob licença BSD-3-Clause.
+;; Leia abaixo a licença que governa este arquivo e verifique a licença de cada repositório
+;; para obter mais informações sobre seus direitos e obrigações ao utilizar e reutilizar
+;; o código deste ou de outros arquivos.
+;;
+;; English:
+;;
+;; The Hexagon, the Hexagonix and its components are licensed under a BSD-3-Clause license.
+;; Read below the license that governs this file and check each repository's license for
+;; obtain more information about your rights and obligations when using and reusing
+;; the code of this or other files.
+;;
+;;************************************************************************************
+;;
+;; BSD 3-Clause License
+;;
+;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; All rights reserved.
+;;
+;; Redistribution and use in source and binary forms, with or without
+;; modification, are permitted provided that the following conditions are met:
+;;
+;; 1. Redistributions of source code must retain the above copyright notice, this
+;;    list of conditions and the following disclaimer.
+;;
+;; 2. Redistributions in binary form must reproduce the above copyright notice,
+;;    this list of conditions and the following disclaimer in the documentation
+;;    and/or other materials provided with the distribution.
+;;
+;; 3. Neither the name of the copyright holder nor the names of its
+;;    contributors may be used to endorse or promote products derived from
+;;    this software without specific prior written permission.
+;;
+;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+;; DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+;; FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+;; DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+;; SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+;; CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+;; OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+;; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;;
+;; $HexagonixOS$
+
+;;************************************************************************************
+;;
+;;                     This file is part of the Hexagon kernel
+;;
+;;************************************************************************************
+
+;;************************************************************************************
+;;
+;;                     Hexagon kernel process scheduler
+;;
+;; This is the round-robin scheduler, responsible for choosing which process
+;; runs next and performing the context switch between ready processes in
+;; Hexagon.Processes.Table
+;;
+;;************************************************************************************
+
+;;************************************************************************************
+;;
+;; Hexagon process scheduling
+;;
+;;************************************************************************************
+
+use32
+
+;;************************************************************************************
+
+Hexagon.Kern.Sched.setupScheduler:
+
+    logHexagon Hexagon.Verbose.heapKernel, Hexagon.Dmesg.Priorities.p5
+
+    push ds
+    pop es
+
+    mov edi, Hexagon.Processes.Table.state
+    mov ecx, Hexagon.Processes.Table.limit
+    mov al, Hexagon.Processes.Table.States.free
+
+    rep stosb
+
+    mov dword[Hexagon.Processes.Table.nextPID], 0
+
+    mov byte[Hexagon.Scheduler.current], 0xFF
+
+    logHexagon Hexagon.Verbose.scheduler, Hexagon.Dmesg.Priorities.p5
+
+    ret
+
+;;************************************************************************************
+;;
+;;                     Round-robin scheduler over Hexagon.Processes.Table
+;;
+;;************************************************************************************
+
+Hexagon.Scheduler.current: db 0xFF ;; 0xFF = kernel boot context, else a Hexagon.Processes.Table index
+Hexagon.Scheduler.ticks:   dd 0
+Hexagon.Scheduler.sliceLength = 5  ;; Timer ticks per time-slice
+
+;;************************************************************************************
+
+;; Reprograms the user code/data segment base in the GDT
+;;
+;; Input:
+;;
+;; EAX - New base address (preserved across the call)
+
+Hexagon.Kern.Sched.setUserSegmentBase:
+
+    push eax
+    push edx
+
+    mov edx, eax
+    and eax, 0xFFFF
+
+    mov word[GDT.userCode + 2], ax
+    mov word[GDT.userData + 2], ax
+
+    mov eax, edx
+
+    shr eax, 16
+    and eax, 0xFF
+
+    mov byte[GDT.userCode + 4], al
+    mov byte[GDT.userData + 4], al
+
+    mov eax, edx
+
+    shr eax, 24
+    and eax, 0xFF
+
+    mov byte[GDT.userCode + 7], al
+    mov byte[GDT.userData + 7], al
+
+    lgdt[GDTReg]
+
+    pop edx
+    pop eax
+
+    ret
+
+;;************************************************************************************
+
+;; Builds a fresh iret frame for a slot's very first dispatch and jumps into
+;; it. Shared by Hexagon.Kern.Proc.exec (launching a fresh child) and
+;; Hexagon.Kern.Sched.maybeSchedule (first dispatch of a spawned process).
+;; Never returns to its caller. Reached with a plain "jmp", not "call"
+;;
+;; Input:
+;;
+;; EBX - Slot index to dispatch
+
+Hexagon.Kern.Sched.dispatchSlot:
+
+    mov eax, dword[Hexagon.Processes.Table.base + ebx * 4]
+
+    call Hexagon.Kern.Sched.setUserSegmentBase
+
+    mov ecx, dword[Hexagon.Processes.Table.size + ebx * 4]
+
+    add eax, ecx
+    sub eax, 4 ;; Small headroom from the very top of the block
+
+    mov esp, eax ;; Top of this process's own allocated block
+
+    call Hexagon.Kern.Proc.calculateArgumentsAddress ;; EDI = arguments address for the new process
+
+    sti ;; Make sure interrupts are available
+
+    pushfd   ;; Flags
+
+    push 30h ;; User environment code segment (process)
+    push dword[Hexagon.Processes.Table.entry + ebx * 4] ;; Image entry point
+
+    mov ax, 38h ;; User environment data segment (process)
+    mov ds, ax
+
+    iret
+
+;;************************************************************************************
+
+;; Called from Hexagon.Kern.Services.timerHandler, via "call", once per
+;; time-slice. At that point EAX and DS are already saved on the current
+;; stack and ds already points at the kernel data segment. Looks for the next
+;; READY process in round-robin order. Ends with a plain "ret" either way:
+;; with nothing else ready, that returns to the caller normally; when
+;; switching, it returns into whatever context is being resumed, at the same
+;; point in its own earlier call to this function, using the stack-swap
+;; itself to carry the CPU state across
+
+Hexagon.Kern.Sched.maybeSchedule:
+
+    pusha
+
+;; Wake any process whose Hexagon.Kern.Sched.sleep wait has expired,
+;; promoting it back to READY so the round robin scan below picks it up
+;; like any other ready process
+
+    xor ebx, ebx
+
+.wakeScan:
+
+    cmp ebx, Hexagon.Processes.Table.limit
+    jae .wakeScanDone
+
+    cmp byte[Hexagon.Processes.Table.state + ebx], Hexagon.Processes.Table.States.sleeping
+    jne .wakeScanNext
+
+;; timerCounter is a plain 32 bit counter, incremented once per tick with no
+;; special handling at the top. After roughly 497 days of uptime at 100 Hz
+;; it silently wraps from FFFFFFFFh back to 0, the same way any fixed width
+;; counter does. A wakeTick recorded just before that wrap (say FFFFFFF0h
+;; plus a 100 tick sleep, landing on 54h once the add itself wraps) would
+;; look, to a plain unsigned comparison, like it has already been reached
+;; the moment timerCounter is still sitting at FFFFFFF1h, since FFFFFFF1h
+;; is numerically far greater than 54h. The process would wake almost
+;; immediately instead of waiting out its real 99 remaining ticks
+;;
+;; Subtracting instead of comparing sidesteps this. timerCounter minus
+;; wakeTick is computed the same way regardless of whether either value has
+;; wrapped, since 32 bit subtraction is itself circular, modulo 2^32. What
+;; changes is how the result is read afterward. FFFFFFF1h minus 54h is
+;; FFFFFF9Dh, which read as an unsigned number looks enormous, but read as
+;; signed two's complement is exactly -99, the correct remaining distance.
+;; jl reads it that way, jumping while the signed result is still negative
+;; and falling through once it reaches zero. jl is used rather than js
+;; because it checks SF against OF rather than the sign bit alone, which
+;; also covers the case where the subtraction itself overflows as signed
+;; arithmetic
+;;
+;; This only holds while the true distance between the two values stays
+;; under half the counter's range, 2^31 ticks, around 248 days. Past that
+;; point a circular comparison can no longer tell which direction is really
+;; closer. Every sleep requested through Hexagon.Kern.Sched.sleep is on the
+;; order of seconds, nowhere near that limit
+
+    mov eax, dword[Hexagon.Kern.Services.timerHandler.timerCounter]
+    sub eax, dword[Hexagon.Processes.Table.wakeTick + ebx * 4]
+
+    jl .wakeScanNext
+
+    mov byte[Hexagon.Processes.Table.state + ebx], Hexagon.Processes.Table.States.ready
+
+.wakeScanNext:
+
+    inc ebx
+
+    jmp .wakeScan
+
+.wakeScanDone:
+
+    movzx edx, byte[Hexagon.Scheduler.current] ;; EDX = who is running now
+
+    cmp edx, 0xFF
+    je .noSwitch ;; Still in raw kernel-boot context, nothing to preempt yet
+
+    mov ebx, edx ;; EBX = scan cursor
+
+.scan:
+
+    inc ebx
+
+    cmp ebx, Hexagon.Processes.Table.limit
+    jb .checkCandidate
+
+    xor ebx, ebx
+
+.checkCandidate:
+
+;; Scanned all the way back to whoever is already running. Nobody else is
+;; ready, stay put
+
+    cmp ebx, edx
+    je .noSwitch
+
+    cmp byte[Hexagon.Processes.Table.state + ebx], Hexagon.Processes.Table.States.ready
+    je .candidateValid
+
+    jmp .scan
+
+.candidateValid:
+
+;; EBX = target slot to switch to, EDX = who is running now
+
+    mov dword[Hexagon.Processes.Table.esp + edx * 4], esp
+
+    mov byte[Hexagon.Processes.Table.state + edx], Hexagon.Processes.Table.States.ready
+    mov byte[Hexagon.Processes.Table.state + ebx], Hexagon.Processes.Table.States.running
+
+    mov byte[Hexagon.Scheduler.current], bl
+
+    cmp dword[Hexagon.Processes.Table.esp + ebx * 4], 0
+    jne .resumeSlot
+
+    jmp Hexagon.Kern.Sched.dispatchSlot ;; First ever dispatch of this slot
+
+.resumeSlot:
+
+    mov eax, dword[Hexagon.Processes.Table.base+ebx*4]
+
+    call Hexagon.Kern.Sched.setUserSegmentBase
+
+    mov esp, dword[Hexagon.Processes.Table.esp+ebx*4]
+
+    popa
+
+    ret
+
+.noSwitch:
+
+    popa
+
+    ret
+
+;;************************************************************************************
+
+;; Puts the calling process to sleep for the given number of ticks without
+;; occupying a round robin slot the whole time. Hexagon.Kern.Sched.maybeSchedule
+;; wakes it back up once Hexagon.Kern.Services.timerHandler.timerCounter
+;; reaches the requested tick, promoting it back to READY on its own next pass
+;;
+;; Input:
+;;
+;; ECX - Ticks to sleep, in counting units
+
+Hexagon.Kern.Sched.sleep:
+
+    pusha
+
+;; Keep the scan and the state transition below atomic against a concurrent,
+;; timer-driven Hexagon.Kern.Sched.maybeSchedule. hexagonHandler always
+;; enables interrupts before reaching any syscall routine, so a plain "sti"
+;; further down is enough to put them back the way they were found
+
+    cli
+
+    movzx edx, byte[Hexagon.Scheduler.current] ;; EDX = own slot
+
+    add ecx, dword[Hexagon.Kern.Services.timerHandler.timerCounter] ;; ECX = absolute wake tick
+
+    mov ebx, edx ;; EBX = scan cursor
+
+.scan:
+
+    inc ebx
+
+    cmp ebx, Hexagon.Processes.Table.limit
+    jb .checkCandidate
+
+    xor ebx, ebx
+
+.checkCandidate:
+
+;; Scanned the whole table without finding anyone else ready. Sleeping here
+;; would leave nothing running at all, so wait it out directly instead
+
+    cmp ebx, edx
+    je .noCandidate
+
+    cmp byte[Hexagon.Processes.Table.state + ebx], Hexagon.Processes.Table.States.ready
+    je .candidateFound
+
+    jmp .scan
+
+.noCandidate:
+
+    sti
+
+.busyWait:
+
+;; Signed difference, same wraparound-safe comparison used by the wake scan
+;; in Hexagon.Kern.Sched.maybeSchedule
+
+    mov eax, dword[Hexagon.Kern.Services.timerHandler.timerCounter]
+    sub eax, ecx
+
+    jl .busyWait
+
+    popa
+
+    ret
+
+.candidateFound:
+
+;; EBX = target slot to switch to, EDX = own slot, ECX = own wake tick
+
+    mov dword[Hexagon.Processes.Table.wakeTick + edx * 4], ecx
+    mov dword[Hexagon.Processes.Table.esp + edx * 4], esp
+
+    mov byte[Hexagon.Processes.Table.state + edx], Hexagon.Processes.Table.States.sleeping
+    mov byte[Hexagon.Processes.Table.state + ebx], Hexagon.Processes.Table.States.running
+
+    mov byte[Hexagon.Scheduler.current], bl
+
+;; Table.esp[edx] above is a clean, pusha-only frame now, exactly what the
+;; ordinary wake path in Hexagon.Kern.Sched.maybeSchedule expects to resume
+;; through later, so interrupts can safely come back on here
+
+    sti
+
+    cmp dword[Hexagon.Processes.Table.esp + ebx * 4], 0
+    jne .resumeSlot
+
+    jmp Hexagon.Kern.Sched.dispatchSlot ;; First ever dispatch of this slot
+
+.resumeSlot:
+
+    mov eax, dword[Hexagon.Processes.Table.base + ebx * 4]
+
+    call Hexagon.Kern.Sched.setUserSegmentBase
+
+    mov esp, dword[Hexagon.Processes.Table.esp + ebx * 4]
+
+    popa
+
+    ret
+
+;;************************************************************************************
+
+;; Returns the physical base address of whichever process is actually
+;; running right now. Hexagon.Kern.Syscall.hexagonHandler uses this to
+;; translate ESI/EDI, and Hexagon.Libkern.Graphics.drawBlockSyscall uses it
+;; the same way for graphics coordinates
+;;
+;; Output:
+;;
+;; EAX - Base address, or 0 if no process is running
+
+Hexagon.Kern.Sched.getCurrentProcessBase:
+
+    push ebx
+
+    movzx ebx, byte[Hexagon.Scheduler.current]
+
+    cmp ebx, 0xFF
+    je .none
+
+    mov eax, dword[Hexagon.Processes.Table.base + ebx * 4]
+
+    jmp .end
+
+.none:
+
+    xor eax, eax
+
+.end:
+
+    pop ebx
+
+    ret

--- a/kern/services.asm
+++ b/kern/services.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/kern/services.asm
+++ b/kern/services.asm
@@ -144,7 +144,7 @@ Hexagon.Kern.Services.timerHandler:
 
     mov al, 20h
 
-    out 20h, al ;; Sent unconditionally and up front - Hexagon.Kern.Proc.maybeSchedule
+    out 20h, al ;; Sent unconditionally and up front. Hexagon.Kern.Sched.maybeSchedule
                 ;; below may switch to a different context and not return here
                 ;; for a while, and IRQ0 needs to be re-armed regardless
 
@@ -155,7 +155,7 @@ Hexagon.Kern.Services.timerHandler:
 
     mov dword[Hexagon.Scheduler.ticks], 0
 
-    call Hexagon.Kern.Proc.maybeSchedule
+    call Hexagon.Kern.Sched.maybeSchedule
 
 .noSchedule:
 
@@ -250,7 +250,7 @@ Hexagon.Kern.Services.keyboardHandler:
 
 .killCurrentProcess:
 
-    call Hexagon.Kern.Proc.kill
+    call Hexagon.Kern.Proc.killForegroundProcess
 
 ;;************************************************************************************
 

--- a/kern/syscall.asm
+++ b/kern/syscall.asm
@@ -114,7 +114,7 @@ Hexagon.Kern.Syscall.hexagonHandler:
 
     mov dword[Hexagon.Syscall.Control.eax], eax
 
-    call Hexagon.Kern.Proc.getCurrentProcessBase ;; EAX = base of whichever process is running now
+    call Hexagon.Kern.Sched.getCurrentProcessBase ;; EAX = base of whichever process is running now
 
     add esi, eax
 
@@ -189,7 +189,7 @@ Hexagon.Kern.Syscall.hexagonHandler:
 
     push eax
 
-    call Hexagon.Kern.Proc.getCurrentProcessBase ;; EAX = base of whichever process is running now
+    call Hexagon.Kern.Sched.getCurrentProcessBase ;; EAX = base of whichever process is running now
 
     mov ebp, eax ;; EBP is free here. CS/EIP were already pushed above
 

--- a/kern/syscall.asm
+++ b/kern/syscall.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/kern/systab.asm
+++ b/kern/systab.asm
@@ -117,7 +117,7 @@ Hexagon.Kern.Syscall.hexagonServices:
     dd Hexagon.Kern.Uname.uname                                        ;; 23
     dd Hexagon.Libkern.Num.getRandomNumber                             ;; 24
     dd Hexagon.Libkern.Num.feedRandomGenerator                         ;; 25
-    dd Hexagon.Arch.i386.Timer.Timer.sleep                             ;; 26
+    dd Hexagon.Kern.Sched.sleep                                        ;; 26
     dd Hexagon.Kern.Syscall.installInterruption                        ;; 27
 
 ;; Hexagon power management
@@ -189,10 +189,7 @@ Hexagon.Kern.Syscall.hexagonServices:
 
     dd Hexagon.Kernel.FS.VFS.changeDirectory                           ;; 69
 
-;; Multitasking (non-blocking process creation)
+;; Multitasking
 
     dd Hexagon.Kern.Proc.spawn                                         ;; 70
-
-;; Kill a process by PID
-
-    dd Hexagon.Kern.Proc.killPID                                       ;; 71
+    dd Hexagon.Kern.Proc.kill                                          ;; 71

--- a/kern/systab.asm
+++ b/kern/systab.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/kern/uname.asm
+++ b/kern/uname.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/kern/users.asm
+++ b/kern/users.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/kern/verbose.asm
+++ b/kern/verbose.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/kern/version.asm
+++ b/kern/version.asm
@@ -83,13 +83,13 @@ use32
 
 Hexagon.Arch.support = 1 ;; Architecture of this image
 
-Hexagon.Version.definition equ "1.6.1"
+Hexagon.Version.definition equ "1.6.2"
 
 Hexagon.Version:
 
 .versionNumber     = 1 ;; Hexagon major version number
 .subversionNumber  = 6 ;; Hexagon minor version number
-.revision          = 1 ;; Add revision character (if necessary, between quotation marks)
+.revision          = 2 ;; Add revision character (if necessary, between quotation marks)
 
 .kernelName: ;; Name given to userspace
 db "Hexagon", 0

--- a/kern/version.asm
+++ b/kern/version.asm
@@ -83,13 +83,13 @@ use32
 
 Hexagon.Arch.support = 1 ;; Architecture of this image
 
-Hexagon.Version.definition equ "1.6.0"
+Hexagon.Version.definition equ "1.6.1"
 
 Hexagon.Version:
 
 .versionNumber     = 1 ;; Hexagon major version number
 .subversionNumber  = 6 ;; Hexagon minor version number
-.revision          = 0 ;; Add revision character (if necessary, between quotation marks)
+.revision          = 1 ;; Add revision character (if necessary, between quotation marks)
 
 .kernelName: ;; Name given to userspace
 db "Hexagon", 0

--- a/kern/version.asm
+++ b/kern/version.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/kern/version.asm
+++ b/kern/version.asm
@@ -83,13 +83,13 @@ use32
 
 Hexagon.Arch.support = 1 ;; Architecture of this image
 
-Hexagon.Version.definition equ "1.5.1"
+Hexagon.Version.definition equ "1.6.0"
 
 Hexagon.Version:
 
 .versionNumber     = 1 ;; Hexagon major version number
-.subversionNumber  = 5 ;; Hexagon minor version number
-.revision          = 1 ;; Add revision character (if necessary, between quotation marks)
+.subversionNumber  = 6 ;; Hexagon minor version number
+.revision          = 0 ;; Add revision character (if necessary, between quotation marks)
 
 .kernelName: ;; Name given to userspace
 db "Hexagon", 0

--- a/kern/version.asm
+++ b/kern/version.asm
@@ -83,13 +83,13 @@ use32
 
 Hexagon.Arch.support = 1 ;; Architecture of this image
 
-Hexagon.Version.definition equ "1.6.2"
+Hexagon.Version.definition equ "1.6.0"
 
 Hexagon.Version:
 
 .versionNumber     = 1 ;; Hexagon major version number
 .subversionNumber  = 6 ;; Hexagon minor version number
-.revision          = 2 ;; Add revision character (if necessary, between quotation marks)
+.revision          = 0 ;; Add revision character (if necessary, between quotation marks)
 
 .kernelName: ;; Name given to userspace
 db "Hexagon", 0

--- a/libkern/HAPP.asm
+++ b/libkern/HAPP.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/libkern/clock.asm
+++ b/libkern/clock.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/libkern/font.asm
+++ b/libkern/font.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/libkern/font/default.asm
+++ b/libkern/font/default.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/libkern/graphics.asm
+++ b/libkern/graphics.asm
@@ -261,9 +261,9 @@ Hexagon.Libkern.Graphics.putPixel:
 
 Hexagon.Libkern.Graphics.drawBlockSyscall:
 
-    push eax ;; X - getCurrentProcessBase below returns its result in eax, save X first
+    push eax ;; X - getCurrentProcessBase below returns its result in EAX, save X first
 
-    call Hexagon.Kern.Proc.getCurrentProcessBase ;; eax = base of whichever process is running now
+    call Hexagon.Kern.Sched.getCurrentProcessBase ;; EAX = base of whichever process is running now
 
     mov ecx, eax
 
@@ -299,15 +299,15 @@ Hexagon.Libkern.Graphics.drawBlockSyscall:
 
 ;;************************************************************************************
 
-;; Desenhar um bloco de cor específica
+;; Draw a block of a specific color
 ;;
-;; Entrada:
+;; Input:
 ;;
 ;; EAX - X
 ;; EBX - Y
-;; ESI - Comprimento
-;; EDI - Largura
-;; EDX - Cor em hexadecimal
+;; ESI - Length
+;; EDI - Width
+;; EDX - Color in hexadecimal
 
 Hexagon.Libkern.Graphics.drawBlock:
 

--- a/libkern/graphics.asm
+++ b/libkern/graphics.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/libkern/macros.s
+++ b/libkern/macros.s
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/libkern/num.asm
+++ b/libkern/num.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/libkern/string.asm
+++ b/libkern/string.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/libkern/stubHAPP.asm
+++ b/libkern/stubHAPP.asm
@@ -12,7 +12,7 @@
 ;;
 ;;                          Kernel Hexagon - Hexagon kernel
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                Todos os direitos reservados - All rights reserved.
 ;;
 ;;************************************************************************************
@@ -35,7 +35,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
- Splits proc.asm into proc.asm and a new sched.asm;
- Adds a SLEEPING process state and an hx.sleep syscall;
 - Adds a real idle process at PID 0, fixing a false panic when a parentless process (like login) exits and nothing else is ready to run;
- Reduces the scheduler quantum from 5 to 1 tick for more responsive multitasking;
- Fixes killing the idle process;
-  malloc and free now account memory usage automatically;
- Fixes a race condition where top/ps could show a process in the wrong state, and where one process's command line arguments could get overwritten by another's (both now use per process buffers, freed on exit and on error paths);
- Closes two unprotected windows around hx.exec/hx.exit where a timer preemption could corrupt a process's saved state;
- Copyright year bump